### PR TITLE
Add remote chat history support

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -35,3 +35,6 @@ Launch the backend API (FastAPI), back to root directory, run:
 ```bash
 uvicorn src.api_server:app --reload
 ```
+
+Both the local and remote agent modes now preserve chat history. Switching
+between them fetches the corresponding conversation from the backend.

--- a/ui/src/pages/Chat.vue
+++ b/ui/src/pages/Chat.vue
@@ -72,12 +72,9 @@ async function askAgent() {
 }
 
 async function loadHistory() {
-  if (useRemote.value) {
-    messages.value = [];
-    return;
-  }
+  const endpoint = useRemote.value ? '/api/remote/history' : '/api/local/history';
   try {
-    const res = await axios.get('/api/local/history');
+    const res = await axios.get(endpoint);
     messages.value = res.data.history || [];
     inputAtBottom.value = messages.value.length > 0;
   } catch {
@@ -89,11 +86,10 @@ async function loadHistory() {
 async function clearHistory() {
   messages.value = [];
   inputAtBottom.value = false;
-  if (!useRemote.value) {
-    try {
-      await axios.post('/api/local/clear');
-    } catch {}
-  }
+  const endpoint = useRemote.value ? '/api/remote/clear' : '/api/local/clear';
+  try {
+    await axios.post(endpoint);
+  } catch {}
 }
 
 onMounted(loadHistory);


### PR DESCRIPTION
## Summary
- keep a single thread for the remote assistant so prior messages are reused
- expose `/api/remote/history` and `/api/remote/clear`
- fetch history/clear endpoints from the UI when in remote mode
- document that both modes preserve chat history now

## Testing
- `npm run build` *(fails: vue-tsc not found)*