### PR TITLE
Improve handling of missing environment variables

### DIFF
--- a/src/export_neo4j_schema.py
+++ b/src/export_neo4j_schema.py
@@ -5,14 +5,19 @@ import json
 from pathlib import Path
 from neo4j import GraphDatabase
 from utils import get_env_variable
+import sys
 
 def main():
     parser = argparse.ArgumentParser(description="Export Neo4j schema.")
     parser.add_argument("--output_dir", required=True, help="Path to store neo4j_schema.json")
     args = parser.parse_args()
 
-    uri      = get_env_variable("DB_URL")
-    db_name  = get_env_variable("DB_NAME")
+    try:
+        uri = get_env_variable("DB_URL")
+        db_name = get_env_variable("DB_NAME")
+    except EnvironmentError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        raise SystemExit(1)
 
     # ---- auth (uncomment if needed) ----
     # user     = get_env_variable("DB_USER")

--- a/src/text2cypher_agent.py
+++ b/src/text2cypher_agent.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json
 import uuid
+import sys
 
 from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI
@@ -87,7 +88,12 @@ class Text2CypherAgent:
         _HISTORY_STORE[self.session_id] = ChatMessageHistory()
 
 if __name__ == "__main__":
-    agent = Text2CypherAgent()
+    try:
+        agent = Text2CypherAgent()
+    except EnvironmentError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
     try:
         while True:
             txt = input("You> ").strip()

--- a/src/utils.py
+++ b/src/utils.py
@@ -17,7 +17,30 @@ def get_project_root() -> Path:
 
 
 def get_env_variable(name: str, default=None, resolve_path=False) -> str:
-    value = os.getenv(name, default)
+    """Return the value of ``name`` from the environment.
+
+    Parameters
+    ----------
+    name: str
+        Environment variable name.
+    default: Any, optional
+        Value to return if the variable is missing.  If ``None`` and the
+        variable is not set, an :class:`EnvironmentError` is raised.
+    resolve_path: bool, optional
+        If ``True`` and the value represents a path, resolve it relative to the
+        project root.
+    """
+
+    if default is None:
+        value = os.getenv(name)
+        if value is None:
+            raise EnvironmentError(
+                f"Required environment variable '{name}' is not set and no "
+                "default value was provided."
+            )
+    else:
+        value = os.getenv(name, default)
+
     if value and resolve_path:
         project_root = get_project_root()
         resolved_path = (project_root / value).resolve()


### PR DESCRIPTION
## Summary
- raise clear `EnvironmentError` when required env vars are missing
- catch the error when starting the CLI agent or exporting schema

## Testing
- `python -m py_compile src/utils.py src/text2cypher_agent.py src/export_neo4j_schema.py`
- `python -m py_compile $(git ls-files '*.py')`
