### PR TITLE
Add schema viewer endpoint and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A new web-based UI <img src="ui/src/assets/logo.png" width="50" alt="Text to Cyp
 
 <img src="ui/src/assets/text-to-cypher-ui-overview.png" width="600" alt="Text to Cypher UI">
 
+The backend now exposes `/api/schema`, returning the loaded Neo4j schema as JSON. The UI shows this information in a side panel for quick reference.
 For more details and setup instructions, see the [UI README](ui/README.md).
 
 ---

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -20,6 +20,7 @@ from openai import OpenAI
 
 from src.text2cypher_agent import Text2CypherAgent
 from src.utils import get_env_variable
+from src.schema_loader import get_schema
 
 load_dotenv()
 OPENAI_ASSISTANT_ID = get_env_variable("OPENAI_ASSISTANT_ID")
@@ -44,6 +45,14 @@ cypher_agent = Text2CypherAgent()
 # ── request model ────────────────────────────────────────────────────
 class QueryRequest(BaseModel):
     query: str
+
+# --------------------------------------------------------------------
+# Schema endpoint
+# --------------------------------------------------------------------
+@app.get("/api/schema", tags=["schema"])
+async def fetch_schema():
+    """Return the cached Neo4j schema JSON."""
+    return get_schema()
 
 # --------------------------------------------------------------------
 # LOCAL agent endpoint

--- a/tests/test_schema_endpoint.py
+++ b/tests/test_schema_endpoint.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+import sys
+import types
+import unittest
+
+sys.modules.setdefault('dotenv', types.SimpleNamespace(load_dotenv=lambda: None))
+sys.modules.setdefault('openai', types.SimpleNamespace(OpenAI=lambda: None))
+sys.modules.setdefault(
+    'src.text2cypher_agent',
+    types.SimpleNamespace(
+        Text2CypherAgent=type(
+            'Dummy',
+            (),
+            {
+                'respond': lambda self, q: '',
+                'get_history': lambda self: [],
+                'clear_history': lambda self: None,
+            },
+        )
+    ),
+)
+
+os.environ.setdefault('OPENAI_ASSISTANT_ID', 'dummy')
+os.environ.setdefault('NEO4J_SCHEMA_PATH', 'data/input/neo4j_schema.json')
+
+import src.api_server as api_server
+
+
+class SchemaEndpointTest(unittest.TestCase):
+    def test_schema_keys(self):
+        schema = asyncio.run(api_server.fetch_schema())
+        self.assertIn('NodeTypes', schema)
+        self.assertIn('RelationshipTypes', schema)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/ui/README.md
+++ b/ui/README.md
@@ -31,3 +31,6 @@ Launch the backend API (FastAPI), back to root directory, run:
 ```bash
 uvicorn src.api_server:app --reload
 ```
+
+The backend exposes `/api/schema`, which the UI fetches to display a "Schema Viewer" panel listing all node labels and relationship types.
+

--- a/ui/src/components/SchemaViewer.vue
+++ b/ui/src/components/SchemaViewer.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="p-4 text-sm overflow-y-auto h-full flex flex-col gap-4">
+    <h1 class="text-lg font-semibold">Neo4j Schema</h1>
+    <div>
+      <h2 class="font-semibold mb-2">Node Labels</h2>
+      <div v-for="(props, label) in schema.NodeTypes" :key="label" class="mb-3">
+        <h3 class="font-medium">{{ label }}</h3>
+        <ul class="list-disc ml-4">
+          <li v-for="(type, prop) in props" :key="prop">
+            <span class="font-mono">{{ prop }}</span>: {{ type }}
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div>
+      <h2 class="font-semibold mb-2 mt-4">Relationship Types</h2>
+      <div
+        v-for="(info, rel) in schema.RelationshipTypes"
+        :key="rel"
+        class="mb-3"
+      >
+        <h3 class="font-medium">{{ rel }}</h3>
+        <p class="text-xs text-gray-500">
+          ({{ info._endpoints?.[0] }}) -[{{ rel }}]-> ({{ info._endpoints?.[1] }})
+        </p>
+        <ul
+          v-if="Object.keys(filterProps(info)).length"
+          class="list-disc ml-4"
+        >
+          <li v-for="(type, prop) in filterProps(info)" :key="prop">
+            <span class="font-mono">{{ prop }}</span>: {{ type }}
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import axios from 'axios'
+
+const schema = ref({ NodeTypes: {}, RelationshipTypes: {} })
+
+function filterProps(info) {
+  const copy = { ...info }
+  delete copy._endpoints
+  return copy
+}
+
+onMounted(async () => {
+  try {
+    const res = await axios.get('/api/schema')
+    schema.value = res.data
+  } catch (err) {
+    console.error('Failed to load schema', err)
+  }
+})
+</script>

--- a/ui/src/pages/Chat.vue
+++ b/ui/src/pages/Chat.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="w-full h-screen flex justify-center px-4 pt-10">
-    <div class="w-full max-w-3xl flex flex-col gap-4 h-full">
+  <div class="w-full h-screen flex justify-center">
+    <div class="flex flex-col gap-4 h-full w-full max-w-3xl px-4 pt-10">
       <div class="text-center">
         <div class="flex justify-center items-center mb-4">
           <img src="../assets/logo.png" alt="Logo" class="h-38 w-auto" />
@@ -33,6 +33,9 @@
         @update:useRemote="useRemote = $event"
       />
     </div>
+    <div class="w-1/3 border-l overflow-y-auto hidden sm:block">
+      <SchemaViewer class="h-full" />
+    </div>
   </div>
 </template>
 
@@ -41,6 +44,7 @@ import { ref, watch, onMounted } from 'vue';
 import axios from 'axios';
 import QueryForm from '../components/QueryForm.vue';
 import ChatHistory from '../components/ChatHistory.vue';
+import SchemaViewer from '../components/SchemaViewer.vue';
 
 const query = ref('');
 const messages = ref([]);


### PR DESCRIPTION
## Summary
- expose Neo4j schema from the backend via `/api/schema`
- display schema information in new `SchemaViewer` Vue component
- adjust `Chat` layout to show schema panel
- document new endpoint in README files
- add unit test for the schema endpoint
- refine UI layout and show property fields in relationship section

## Testing
- `OPENAI_ASSISTANT_ID=dummy NEO4J_SCHEMA_PATH=data/input/neo4j_schema.json PYTHONPATH=. python tests/test_schema_endpoint.py`
- `OPENAI_ASSISTANT_ID=dummy NEO4J_SCHEMA_PATH=data/input/neo4j_schema.json PYTHONPATH=. python tests/test_concurrency.py`
