### PR TITLE
Add quick cypher sidebar

### DIFF
--- a/ui/src/components/QuickCypher.vue
+++ b/ui/src/components/QuickCypher.vue
@@ -1,12 +1,19 @@
 <template>
-  <div class="p-4 text-sm overflow-y-auto h-full flex flex-col gap-4">
+  <div class="p-4 text-sm overflow-y-auto h-full flex flex-col">
     <h1 class="text-lg font-semibold">Quick Cypher</h1>
-    <div v-for="(cypher, idx) in scripts" :key="idx" class="flex flex-col items-start gap-1">
+    <div
+      v-for="(item, idx) in scripts"
+      :key="idx"
+      class="flex flex-col items-start gap-2 mt-6 first:mt-0"
+    >
+      <span class="text-sm font-semibold text-gray-700">
+        {{ item.desc }}
+      </span>
       <MessageBubble
-        :text="cypher"
+        :text="item.query"
         :showRun="true"
-        @run="emit('run-query', cypher)"
-        @copy="copyToClipboard(cypher)"
+        @run="emit('run-query', item.query)"
+        @copy="copyToClipboard(item.query)"
       />
     </div>
   </div>
@@ -28,9 +35,17 @@ function copyToClipboard(text) {
 }
 
 const scripts = [
-  'CALL db.schema.visualization',
-  'SHOW CONSTRAINTS',
-  'SHOW INDEXES',
-  'MATCH (n) RETURN n LIMIT 25'
+  {
+    query: 'CALL db.schema.visualization',
+    desc: 'Visualize the database schema'
+  },
+  {
+    query: 'MATCH (n) RETURN labels(n)[0], count(*)',
+    desc: 'Count nodes by label'
+  },
+  {
+    query: 'MATCH ()-[r]->() RETURN type(r), count(*)',
+    desc: 'Count relationships by type'
+  }
 ]
 </script>

--- a/ui/src/pages/Chat.vue
+++ b/ui/src/pages/Chat.vue
@@ -100,12 +100,12 @@ const windowWidth = ref(window.innerWidth);
 const CHAT_MIN_WIDTH = 320;   // px
 const MAX_MARGIN     = 200;   // px (mx-50)
 
-const schemaWidth   = ref(350); // px
+const schemaWidth   = ref(450); // px
 const showSidebar   = ref(false);    // mobile overlay
 const sidebarVisible = ref(true);    // desktop visibility
 const sidebarTab     = ref('schema');
 const isMobile    = ref(window.innerWidth < 640);
-const SCHEMA_MIN_WIDTH = 240; // px
+const SCHEMA_MIN_WIDTH = 200; // px
 
 function onResize() {
   windowWidth.value = window.innerWidth;


### PR DESCRIPTION
## Summary
- add QuickCypher component listing handy Cypher snippets
- toggleable sidebar now supports Schema or Cypher scripts
- allow showing/hiding sidebar on both desktop and mobile

## Testing
- `pytest -q` *(fails: command not found)*